### PR TITLE
Fix requirements.txt clyent=1.2.1

### DIFF
--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -2,7 +2,7 @@ anaconda-client==1.6.3
 appnope==0.1.0
 bleach==1.5.0
 branca==0.2.0
-clyent==1.2.2
+clyent==1.2.1
 colorama==0.3.9
 cycler==0.10.0
 decorator==4.0.11


### PR DESCRIPTION
Installing the dependencies using `pip` fails because `clyent` in version 1.2.2 is not published on PyPI. Version 1.2.1 is the latest version currently available from PyPI ( https://pypi.org/project/clyent/#history )

Running `test-my-environment.ipynb` works fine (on macOS) with version 1.2.1.